### PR TITLE
Update Dockerfile

### DIFF
--- a/packagist/Dockerfile
+++ b/packagist/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockette/alpine:3.7
+FROM dockette/alpine:3.14
 
 MAINTAINER Milan Sulc <sulcmil@gmail.com>
 


### PR DESCRIPTION
Upgrade to 3.14 to fix the  DST Root CA X3 expired September 29 19:21:40 2021 GMT

https://docs.certifytheweb.com/docs/kb/kb-202109-letsencrypt/